### PR TITLE
WIP: Begin reorganizing the kernel with kernel-space typescript fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+dist/
+package-lock.json

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Getting Started</title>
+  </head>
+  <body>
+    <script src="./build/main.js"></script>
+  </body>
+</html>

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "webabi-example",
+  "version": "0.0.1",
+  "description": "",
+  "scripts": {
+    "build": "tsc",
+    "install": "npm run build",
+    "test": "npm run build && webpack && node build/main.js"
+  },
+  "author": "Will Fancher",
+  "dependencies": {
+    "typescript": "^2.9.2",
+    "webabi-kernel": "file:../kernel"
+  },
+  "devDependencies": {
+    "webpack": "^4.16.3",
+    "webpack-cli": "^3.1.0"
+  }
+}

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "install": "npm run build",
-    "test": "npm run build && webpack && node build/main.js"
+    "test": "npm run build && webpack && (echo bar | node build/main.js)"
   },
   "author": "Will Fancher",
   "dependencies": {

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,6 +1,7 @@
-import { Device, configureFileSystem, BFSCallback,
+import { Device, configureKernel, BFSCallback,
          Stats, File, FileFlag, FS, ApiError,
          ErrorCode, asyncRead, asyncWrite } from "webabi-kernel";
+import { makeWorker, PostMessage, OnMessage } from "webabi-kernel/dist/worker";
 
 class JSaddleDevice implements Device {
   async open(flag: FileFlag): Promise<File> {
@@ -12,11 +13,22 @@ class JSaddleDevice implements Device {
 }
 
 async function main() {
-  let fs = await configureFileSystem({ "/jsaddle": new JSaddleDevice() });
+  let kernel = await configureKernel({ "/jsaddle": new JSaddleDevice() });
+  let fs = kernel.fs;
   let buf = Buffer.from("foo\n");
   await asyncWrite(fs, 1, buf, 0, buf.length, null);
   const { byteLength } = await asyncRead(fs, 0, buf, 0, buf.length, null);
   console.log({ byteLength: byteLength, buffer: buf.toString() });
+
+  console.log("working");
+  let worker: PostMessage;
+  worker = await makeWorker("./exec/build/main.js", {
+    onMessage: msg => {
+      console.log(msg);
+      worker.close();
+    }
+  });
+  worker.postMessage("foo");
 }
 
 main().catch(e => {

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,4 +1,4 @@
-import { Device, configureFileSystem, BFSCallback, Stats, File, FileFlag } from "webabi-kernel";
+import { Device, configureFileSystem, BFSCallback, Stats, File, FileFlag, FS, asyncRead, asyncWrite } from "webabi-kernel";
 
 class JSaddleDevice implements Device {
   open(flag: FileFlag, cb: BFSCallback<File>): void {
@@ -7,12 +7,14 @@ class JSaddleDevice implements Device {
   }
 }
 
-configureFileSystem({ "/jsaddle": new JSaddleDevice() }, (err, fs) => {
-  console.log(err);
+async function main() {
+  let fs = await configureFileSystem({ "/jsaddle": new JSaddleDevice() });
   let buf = Buffer.from("foo\n");
-  fs.write(1, buf, 0, buf.length, null, () => {
-    fs.read(0, buf, 0, 4, null, (err, n, buf) => {
-      console.log({ err: err, n: n, buf: buf && buf.toString() });
-    });
-  });
+  await asyncWrite(fs, 1, buf, 0, buf.length, null);
+  const { byteLength } = await asyncRead(fs, 0, buf, 0, buf.length, null);
+  console.log({ byteLength: byteLength, buffer: buf.toString() });
+}
+
+main().catch(e => {
+  console.error("Error: ", e);
 });

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,0 +1,14 @@
+import { Device, configureFileSystem, BFSCallback, Stats, File, FileFlag } from "webabi-kernel";
+
+class JSaddleDevice implements Device {
+  open(flag: FileFlag, cb: BFSCallback<File>): void {
+  }
+  stat(isLstat: boolean | null, cb: BFSCallback<Stats>): void {
+  }
+}
+
+configureFileSystem({ "/jsaddle": new JSaddleDevice() }, (err, fs) => {
+  console.log(err);
+  let buf = Buffer.from("hi\n");
+  fs.write(1, buf, 0, buf.length, null, () => {});
+});

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,9 +1,13 @@
-import { Device, configureFileSystem, BFSCallback, Stats, File, FileFlag, FS, asyncRead, asyncWrite } from "webabi-kernel";
+import { Device, configureFileSystem, BFSCallback,
+         Stats, File, FileFlag, FS, ApiError,
+         ErrorCode, asyncRead, asyncWrite } from "webabi-kernel";
 
 class JSaddleDevice implements Device {
-  open(flag: FileFlag, cb: BFSCallback<File>): void {
+  async open(flag: FileFlag): Promise<File> {
+    throw new ApiError(ErrorCode.ENOTSUP);
   }
-  stat(isLstat: boolean | null, cb: BFSCallback<Stats>): void {
+  async stat(isLstat: boolean | null): Promise<Stats> {
+    throw new ApiError(ErrorCode.ENOTSUP);
   }
 }
 

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -9,6 +9,10 @@ class JSaddleDevice implements Device {
 
 configureFileSystem({ "/jsaddle": new JSaddleDevice() }, (err, fs) => {
   console.log(err);
-  let buf = Buffer.from("hi\n");
-  fs.write(1, buf, 0, buf.length, null, () => {});
+  let buf = Buffer.from("foo\n");
+  fs.write(1, buf, 0, buf.length, null, () => {
+    fs.read(0, buf, 0, 4, null, (err, n, buf) => {
+      console.log({ err: err, n: n, buf: buf && buf.toString() });
+    });
+  });
 });

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["dom", "es2015", "es2016", "es2017"],
+    "module": "commonjs",
+    "declaration": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,0 +1,16 @@
+const path = require('path');
+
+console.log(require.resolve("webabi-kernel"));
+
+module.exports = {
+  entry: './dist/index.js',
+  mode: "production",
+  output: {
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'build')
+  },
+  resolve: {
+    // Using file:../kernel in package.json requires this
+    symlinks: false
+  }
+};

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -12,5 +12,8 @@ module.exports = {
   resolve: {
     // Using file:../kernel in package.json requires this
     symlinks: false
+  },
+  node: {
+    process: false
   }
 };

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,7 +1,5 @@
 const path = require('path');
 
-console.log(require.resolve("webabi-kernel"));
-
 module.exports = {
   entry: './dist/index.js',
   mode: "production",

--- a/exec/package.json
+++ b/exec/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "webabi-example",
+  "name": "webabi-exec",
   "version": "0.0.1",
   "description": "",
   "scripts": {
     "build": "tsc && webpack",
-    "install": "npm run build",
-    "test": "npm run build && (cd ..; echo bar | node --experimental-worker example/build/main.js)"
+    "install": "npm run build"
   },
+  "main": "dist/index.js",
   "author": "Will Fancher",
   "dependencies": {
-    "typescript": "^2.9.2",
-    "webabi-kernel": "file:../kernel"
+    "typescript": "^2.9.2"
   },
   "devDependencies": {
     "webpack": "^4.16.3",

--- a/exec/src/index.ts
+++ b/exec/src/index.ts
@@ -1,0 +1,14 @@
+import { connectParent, PostMessage } from "./worker";
+
+async function main() {
+  let parent: PostMessage;
+  parent = await connectParent({
+    onMessage: msg => {
+      console.log(msg);
+      parent.close();
+    }
+  });
+  parent.postMessage("bar");
+}
+
+main();

--- a/exec/src/node_worker.ts
+++ b/exec/src/node_worker.ts
@@ -1,8 +1,8 @@
 declare module "worker_threads" {
-  export class Worker {
-    constructor(path: string);
-    postMessage(msg: any, transferList: [any]): void;
+  interface MessagePort {
+    postMessage(msg: any, transferList: [any]);
     on(event: "message", handler: (msg: any) => void);
     unref(): void;
   }
+  export const parentPort: MessagePort;
 }

--- a/exec/src/worker.ts
+++ b/exec/src/worker.ts
@@ -1,0 +1,28 @@
+export interface OnMessage {
+  onMessage(msg: any): void;
+}
+
+export interface PostMessage {
+  postMessage(msg: any, transferList?: [any]): void;
+  close(): void;
+}
+
+export let connectParent: (receiver: OnMessage) => Promise<PostMessage>;
+if (typeof self !== "undefined") {
+  connectParent = async (receiver) => {
+    self.onmessage = msg => receiver.onMessage(msg.data);
+    return {
+      postMessage: (msg, transferList) => self.postMessage(msg, transferList as any /*tsc complains wrongly*/),
+      close: () => {}
+    };
+  };
+} else {
+  connectParent = async (receiver) => {
+    const nodeWorkers = await import("worker_threads");
+    nodeWorkers.parentPort.on("message", msg => receiver.onMessage(msg));
+    return {
+      postMessage: (msg, transferList) => nodeWorkers.parentPort.postMessage(msg, transferList),
+      close: () => nodeWorkers.parentPort.unref()
+    };
+  }
+}

--- a/exec/tsconfig.json
+++ b/exec/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["dom", "es2015", "es2016", "es2017"],
+    "module": "commonjs",
+    "declaration": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/exec/webpack.config.js
+++ b/exec/webpack.config.js
@@ -14,12 +14,5 @@ module.exports = {
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'build')
-  },
-  resolve: {
-    // Using file:../kernel in package.json requires this
-    symlinks: false
-  },
-  node: {
-    process: false
   }
 };

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
     <title>Getting Started</title>
   </head>
   <body>
-    <script src="./build/main.js"></script>
+    <script src="./example/build/main.js"></script>
   </body>
 </html>

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "scripts": {
     "build": "tsc",
-    "main": "npm run tsc && node dist/foo.js",
     "install": "npm run build"
   },
   "main": "dist/index.js",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "webabi-kernel",
+  "version": "0.0.1",
+  "description": "",
+  "scripts": {
+    "build": "tsc",
+    "main": "npm run tsc && node dist/foo.js",
+    "install": "npm run build"
+  },
+  "main": "dist/index.js",
+  "author": "Will Fancher",
+  "dependencies": {
+    "@types/archiver": "^2.0.0",
+    "@types/async": "^2.0.49",
+    "@types/body-parser": "^1.16.4",
+    "@types/dropboxjs": "0.0.29",
+    "@types/express": "^4.0.36",
+    "@types/filesystem": "0.0.28",
+    "@types/isomorphic-fetch": "^0.0.34",
+    "@types/mocha": "^5.2.5",
+    "@types/node": "^7.0",
+    "@types/rimraf": "^2.0.2",
+    "browserfs": "^1.4.3",
+    "typescript": "^2.9.2"
+  }
+}

--- a/kernel/src/DeviceFileSystem.ts
+++ b/kernel/src/DeviceFileSystem.ts
@@ -1,0 +1,63 @@
+import { BaseFileSystem, BFSCallback, FileSystem, FileSystemOptions
+       } from "browserfs/dist/node/core/file_system";
+import Stats from 'browserfs/dist/node/core/node_fs_stats';
+import { File } from "browserfs/dist/node/core/file";
+import { FileFlag } from "browserfs/dist/node/core/file_flag";
+import { ApiError } from 'browserfs/dist/node/core/api_error';
+
+export interface Device {
+  open(flag: FileFlag): Promise<File>;
+  stat(isLstat: boolean | null): Promise<Stats>;
+}
+
+export interface DeviceFileSystemOptions {
+  devices: {[name: string]: Device};
+}
+
+export class DeviceFileSystem extends BaseFileSystem implements FileSystem {
+  public static readonly Name = "DeviceFileSystem";
+  public static readonly Options: FileSystemOptions = {};
+
+  public static Create(opts: DeviceFileSystemOptions, cb: BFSCallback<DeviceFileSystem>): void {
+    return cb(null, new DeviceFileSystem(opts));
+  }
+
+  public static isAvailable(): boolean {
+    return true;
+  }
+
+  options: DeviceFileSystemOptions;
+
+  constructor(options: DeviceFileSystemOptions) {
+    super();
+    this.options = options;
+  }
+
+  public getName() {
+    return "DeviceFileSystem";
+  }
+  public isReadOnly() {
+    return false;
+  }
+  public supportsProps() {
+    return false;
+  }
+  public supportsSynch() {
+    return false;
+  }
+
+  public openFile(p: string, flag: FileFlag, cb: BFSCallback<File>): void {
+    if (this.options.devices.hasOwnProperty(p)) {
+      this.options.devices[p].open(flag).then(f => cb(undefined, f), e => cb(e));
+    } else {
+      cb(ApiError.ENOENT(p));
+    }
+  }
+  public stat(p: string, isLstat: boolean | null, cb: BFSCallback<Stats>): void {
+    if (this.options.devices.hasOwnProperty(p)) {
+      this.options.devices[p].stat(isLstat).then(s => cb(undefined, s), e => cb(e));
+    } else {
+      cb(ApiError.ENOENT(p));
+    }
+  }
+}

--- a/kernel/src/index.ts
+++ b/kernel/src/index.ts
@@ -1,73 +1,15 @@
 import MountableFileSystem from "browserfs/dist/node/backend/MountableFileSystem";
 import * as handles from "./stdio_handles";
-import { BaseFileSystem, FileSystemConstructor, BFSCallback,
-         BFSOneArgCallback, BFSThreeArgCallback, FileSystem,
-         FileSystemOptions } from "browserfs/dist/node/core/file_system";
-import { FileType } from 'browserfs/dist/node/core/node_fs_stats';
+import { BFSCallback } from "browserfs/dist/node/core/file_system";
 import Stats from 'browserfs/dist/node/core/node_fs_stats';
 import { File } from "browserfs/dist/node/core/file";
 import { FileFlag } from "browserfs/dist/node/core/file_flag";
 import { ApiError, ErrorCode } from 'browserfs/dist/node/core/api_error';
 import FS from "browserfs/dist/node/core/FS";
+import { DeviceFileSystem, Device }  from "./DeviceFileSystem";
+import Kernel from "./kernel";
 
-export interface Device {
-  open(flag: FileFlag): Promise<File>;
-  stat(isLstat: boolean | null): Promise<Stats>;
-}
-
-export interface DeviceFileSystemOptions {
-  devices: {[name: string]: Device};
-}
-
-export class DeviceFileSystem extends BaseFileSystem implements FileSystem {
-  public static readonly Name = "DeviceFileSystem";
-  public static readonly Options: FileSystemOptions = {};
-
-  public static Create(opts: DeviceFileSystemOptions, cb: BFSCallback<DeviceFileSystem>): void {
-    return cb(null, new DeviceFileSystem(opts));
-  }
-
-  public static isAvailable(): boolean {
-    return true;
-  }
-
-  options: DeviceFileSystemOptions;
-
-  constructor(options: DeviceFileSystemOptions) {
-    super();
-    this.options = options;
-  }
-
-  public getName() {
-    return "DeviceFileSystem";
-  }
-  public isReadOnly() {
-    return false;
-  }
-  public supportsProps() {
-    return false;
-  }
-  public supportsSynch() {
-    return false;
-  }
-
-  public openFile(p: string, flag: FileFlag, cb: BFSCallback<File>): void {
-    if (this.options.devices.hasOwnProperty(p)) {
-      this.options.devices[p].open(flag).then(f => cb(undefined, f), e => cb(e));
-    } else {
-      cb(ApiError.ENOENT(p));
-    }
-  }
-  public stat(p: string, isLstat: boolean | null, cb: BFSCallback<Stats>): void {
-    if (this.options.devices.hasOwnProperty(p)) {
-      this.options.devices[p].stat(isLstat).then(s => cb(undefined, s), e => cb(e));
-    } else {
-      cb(ApiError.ENOENT(p));
-    }
-  }
-}
-
-export async function configureFileSystem(devices: { [name: string]: Device }): Promise<FS> {
+export async function configureKernel(devices: { [name: string]: Device }): Promise<Kernel> {
   const dfs = await new Promise<DeviceFileSystem>((resolve, reject) => {
     DeviceFileSystem.Create({ devices: devices }, (e, dfs) => e ? reject(e) : resolve(dfs))
   });
@@ -85,7 +27,7 @@ export async function configureFileSystem(devices: { [name: string]: Device }): 
   fdMap[1] = handles.stdout;
   fdMap[2] = handles.stderr;
 
-  return fs;
+  return new Kernel(fs);
 }
 
 export async function asyncRead(fs: FS, fd: number, buffer: Buffer, offset: number, length: number, position: number | null)
@@ -105,3 +47,4 @@ export async function asyncWrite(fs: FS, fd: number, buffer: Buffer, offset: num
 
 // Re-export for device implementors
 export { BFSCallback, Stats, File, FileFlag, FS, ApiError, ErrorCode };
+export * from "./DeviceFileSystem";

--- a/kernel/src/index.ts
+++ b/kernel/src/index.ts
@@ -1,0 +1,98 @@
+import MountableFileSystem from "browserfs/dist/node/backend/MountableFileSystem";
+import * as handles from "./stdio_handles";
+import { BaseFileSystem, FileSystemConstructor, BFSCallback,
+         BFSOneArgCallback, BFSThreeArgCallback, FileSystem,
+         FileSystemOptions } from "browserfs/dist/node/core/file_system";
+import { FileType } from 'browserfs/dist/node/core/node_fs_stats';
+import Stats from 'browserfs/dist/node/core/node_fs_stats';
+import { File } from "browserfs/dist/node/core/file";
+import { FileFlag } from "browserfs/dist/node/core/file_flag";
+import { ApiError, ErrorCode } from 'browserfs/dist/node/core/api_error';
+import FS from "browserfs/dist/node/core/FS";
+
+export interface Device {
+  open(flag: FileFlag, cb: BFSCallback<File>): void;
+  stat(isLstat: boolean | null, cb: BFSCallback<Stats>): void;
+}
+
+export interface DeviceFileSystemOptions {
+  devices: {[name: string]: Device};
+}
+
+export class DeviceFileSystem extends BaseFileSystem implements FileSystem {
+  public static readonly Name = "DeviceFileSystem";
+  public static readonly Options: FileSystemOptions = {};
+
+  public static Create(opts: DeviceFileSystemOptions, cb: BFSCallback<DeviceFileSystem>): void {
+    return cb(null, new DeviceFileSystem(opts));
+  }
+
+  public static isAvailable(): boolean {
+    return true;
+  }
+
+  options: DeviceFileSystemOptions;
+
+  constructor(options: DeviceFileSystemOptions) {
+    super();
+    this.options = options;
+  }
+
+  public getName() {
+    return "DeviceFileSystem";
+  }
+  public isReadOnly() {
+    return false;
+  }
+  public supportsProps() {
+    return false;
+  }
+  public supportsSynch() {
+    return false;
+  }
+
+  public openFile(p: string, flag: FileFlag, cb: BFSCallback<File>): void {
+    if (this.options.devices.hasOwnProperty(p)) {
+      return this.options.devices[p].open(flag, cb);
+    } else {
+      return cb(ApiError.ENOENT(p));
+    }
+  }
+  public stat(p: string, isLstat: boolean | null, cb: BFSCallback<Stats>): void {
+    if (this.options.devices.hasOwnProperty(p)) {
+      return this.options.devices[p].stat(isLstat, cb);
+    } else {
+      return cb(ApiError.ENOENT(p));
+    }
+  }
+}
+
+export function configureFileSystem(devices: { [name: string]: Device }, cb: BFSCallback<FS>): void {
+  DeviceFileSystem.Create({ devices: devices }, (e, dfs) => {
+    if (e) {
+      cb(e);
+      return;
+    }
+    MountableFileSystem.Create({
+      "/dev": dfs
+    }, (e, mfs) => {
+      if (e) {
+        cb(e);
+        return
+      }
+
+      const fs = new FS();
+      fs.initialize(mfs);
+
+      const fdMap: {[id: number]: File} = (fs as any).fdMap;
+      fdMap[0] = handles.stdin;
+      fdMap[1] = handles.stdout;
+      fdMap[2] = handles.stderr;
+
+      cb(undefined, fs);
+    });
+  });
+}
+
+// Re-export for device implementors
+export { BFSCallback, Stats, File, FileFlag };

--- a/kernel/src/index.ts
+++ b/kernel/src/index.ts
@@ -11,8 +11,8 @@ import { ApiError, ErrorCode } from 'browserfs/dist/node/core/api_error';
 import FS from "browserfs/dist/node/core/FS";
 
 export interface Device {
-  open(flag: FileFlag, cb: BFSCallback<File>): void;
-  stat(isLstat: boolean | null, cb: BFSCallback<Stats>): void;
+  open(flag: FileFlag): Promise<File>;
+  stat(isLstat: boolean | null): Promise<Stats>;
 }
 
 export interface DeviceFileSystemOptions {
@@ -53,16 +53,16 @@ export class DeviceFileSystem extends BaseFileSystem implements FileSystem {
 
   public openFile(p: string, flag: FileFlag, cb: BFSCallback<File>): void {
     if (this.options.devices.hasOwnProperty(p)) {
-      return this.options.devices[p].open(flag, cb);
+      this.options.devices[p].open(flag).then(f => cb(undefined, f), e => cb(e));
     } else {
-      return cb(ApiError.ENOENT(p));
+      cb(ApiError.ENOENT(p));
     }
   }
   public stat(p: string, isLstat: boolean | null, cb: BFSCallback<Stats>): void {
     if (this.options.devices.hasOwnProperty(p)) {
-      return this.options.devices[p].stat(isLstat, cb);
+      this.options.devices[p].stat(isLstat).then(s => cb(undefined, s), e => cb(e));
     } else {
-      return cb(ApiError.ENOENT(p));
+      cb(ApiError.ENOENT(p));
     }
   }
 }
@@ -104,4 +104,4 @@ export async function asyncWrite(fs: FS, fd: number, buffer: Buffer, offset: num
 }
 
 // Re-export for device implementors
-export { BFSCallback, Stats, File, FileFlag, FS };
+export { BFSCallback, Stats, File, FileFlag, FS, ApiError, ErrorCode };

--- a/kernel/src/kernel.ts
+++ b/kernel/src/kernel.ts
@@ -1,0 +1,9 @@
+import FS from "browserfs/dist/node/core/FS";
+import { makeWorker, PostMessage, OnMessage } from "./worker";
+
+export default class Kernel {
+  fs: FS;
+  constructor(fs: FS) {
+    this.fs = fs;
+  };
+}

--- a/kernel/src/node_parent.ts
+++ b/kernel/src/node_parent.ts
@@ -1,0 +1,7 @@
+declare module "worker_threads" {
+  export class Worker {
+    constructor(path: string);
+    postMessage(msg: any): void;
+    on(event: "message", handler: (msg: any) => void);
+  }
+}

--- a/kernel/src/stdio_handles.ts
+++ b/kernel/src/stdio_handles.ts
@@ -103,6 +103,9 @@ if (!(typeof process === "undefined" || (process as any).browser)) {
         // Use Buffer.from to avoid retaining the entire history.
         this.leftover = Buffer.from(nextBuf);
       }
+      if (this.requests.length > 0) {
+        this.stream.resume();
+      }
     };
     close(cb: BFSOneArgCallback): void {
       this.stream.end(cb);

--- a/kernel/src/stdio_handles.ts
+++ b/kernel/src/stdio_handles.ts
@@ -79,9 +79,9 @@ if (process && !(process as any).browser) {
 
     onData(buf: Buffer): void {
       const reqs = this.requests;
-      this.requests = <[Request]> [];
       let nextBuf: Buffer | null = null;
-      for (const req of reqs) {
+      let req: Request;
+      while (req = this.requests.shift()) {
         if (buf.length > req.length) {
           nextBuf = buf.slice(req.length);
           buf = buf.slice(0, req.length);
@@ -92,6 +92,9 @@ if (process && !(process as any).browser) {
         const copied = buf.copy(req.buffer, req.offset);
         req.cb(undefined, copied, req.buffer);
 
+        if (!nextBuf || nextBuf.length == 0) {
+          break;
+        }
         buf = nextBuf;
       }
 

--- a/kernel/src/stdio_handles.ts
+++ b/kernel/src/stdio_handles.ts
@@ -1,0 +1,170 @@
+import { File, BaseFile } from "browserfs/dist/node/core/file";
+import { BaseFileSystem, FileSystemConstructor, BFSCallback, BFSOneArgCallback, BFSThreeArgCallback, FileSystem, FileSystemOptions } from "browserfs/dist/node/core/file_system";
+import { FileType } from 'browserfs/dist/node/core/node_fs_stats';
+import Stats from 'browserfs/dist/node/core/node_fs_stats';
+import { ApiError, ErrorCode } from 'browserfs/dist/node/core/api_error';
+
+export let stdin: File;
+export let stdout: File;
+export let stderr: File;
+
+class UselessFile extends BaseFile implements File {
+  getPos(): number | undefined {
+    return undefined;
+  }
+  stat(cb: BFSCallback<Stats>): void {
+    return cb(undefined, new Stats(FileType.FILE, 0));
+  }
+  statSync(): Stats {
+    return new Stats(FileType.FILE, 0)
+  }
+  close(cb: BFSOneArgCallback): void {
+    cb(new ApiError(ErrorCode.ENOTSUP));
+  }
+  closeSync(): void {
+    throw new ApiError(ErrorCode.ENOTSUP);
+  }
+  truncate(len: number, cb: BFSOneArgCallback): void {
+    cb(new ApiError(ErrorCode.ENOTSUP));
+  }
+  truncateSync(len: number): void {
+    throw new ApiError(ErrorCode.ENOTSUP);
+  }
+  write(buffer: Buffer, offset: number, length: number, position: number | null, cb: BFSThreeArgCallback<number, Buffer>): void {
+    cb(new ApiError(ErrorCode.ENOTSUP));
+  }
+  writeSync(buffer: Buffer, offset: number, length: number, position: number | null): number {
+    throw new ApiError(ErrorCode.ENOTSUP);
+  }
+  read(buffer: Buffer, offset: number, length: number, position: number | null, cb: BFSThreeArgCallback<number, Buffer>): void {
+    cb(new ApiError(ErrorCode.ENOTSUP));
+  }
+  readSync(buffer: Buffer, offset: number, length: number, position: number): number {
+    throw new ApiError(ErrorCode.ENOTSUP);
+  }
+}
+
+if (process && !(process as any).browser) {
+  interface Request {
+    buffer: Buffer;
+    offset: number;
+    length: number;
+    cb: BFSThreeArgCallback<number, Buffer>;
+  }
+  class ReadWriteStreamFile extends UselessFile implements File {
+    stream: NodeJS.ReadWriteStream;
+    requests: [Request] = <[Request]> [];
+    leftover?: Buffer = null;
+
+    constructor(stream: NodeJS.ReadWriteStream) {
+      super();
+      this.stream = stream;
+      this.stream.pause();
+      this.stream.on("error", (err) => {
+        const reqs = this.requests;
+        this.requests = <[Request]> [];
+        for (const req of reqs) {
+          req.cb(err, undefined, undefined);
+        }
+      });
+      this.stream.on("data", (buf) => {
+        this.stream.pause();
+        if (this.leftover) {
+          buf = Buffer.concat([this.leftover, buf]);
+          this.leftover = null;
+        }
+        this.onData(buf);
+      });
+    }
+
+    onData(buf: Buffer): void {
+      const reqs = this.requests;
+      this.requests = <[Request]> [];
+      let nextBuf: Buffer | null = null;
+      for (const req of reqs) {
+        if (buf.length > req.length) {
+          nextBuf = buf.slice(req.length);
+          buf = buf.slice(0, req.length);
+        } else {
+          nextBuf = null;
+        }
+
+        const copied = buf.copy(req.buffer, req.offset);
+        req.cb(undefined, copied, req.buffer);
+
+        buf = nextBuf;
+      }
+
+      if (nextBuf) {
+        // nextBuf may still have the old leftover underlying it.
+        // Use Buffer.from to avoid retaining the entire history.
+        this.leftover = Buffer.from(nextBuf);
+      }
+    };
+    close(cb: BFSOneArgCallback): void {
+      this.stream.end(cb);
+    }
+    write(buffer: Buffer, offset: number, length: number, position: number | null, cb: BFSThreeArgCallback<number, Buffer>): void {
+      this.stream.write(buffer.slice(offset, offset + length), (err) => {
+        if (err) {
+          cb(err);
+        } else {
+          cb(undefined, length, buffer);
+        }
+      });
+    }
+    read(buffer: Buffer, offset: number, length: number, position: number | null, cb: BFSThreeArgCallback<number, Buffer>): void {
+      this.stream.resume();
+      this.requests.push({
+        buffer: buffer,
+        offset: offset,
+        length: length,
+        cb: cb
+      });
+    }
+  }
+
+  stdin = new ReadWriteStreamFile(process.stdin);
+  stdout = new ReadWriteStreamFile(process.stdout);
+  stderr = new ReadWriteStreamFile(process.stderr);
+} else {
+  class ConsoleFile extends UselessFile implements File {
+    log: (msg: string) => void;
+    buffer?: Buffer = null;
+
+    constructor(log: (msg: string) => void) {
+      super();
+      this.log = log;
+    }
+
+    write(buffer: Buffer, offset: number, length: number, position: number | null, cb: BFSThreeArgCallback<number, Buffer>): void {
+      let slicedBuffer = buffer.slice(offset, offset + length);
+      let n = slicedBuffer.lastIndexOf("\n");
+      if (n < 0) {
+        if (this.buffer) {
+          this.buffer = Buffer.concat([this.buffer, slicedBuffer]);
+        } else {
+          this.buffer = slicedBuffer;
+        }
+      } else {
+        let logBuffer = slicedBuffer.slice(0, n);
+        if (this.buffer) {
+          logBuffer = Buffer.concat([this.buffer, logBuffer]);
+        }
+        this.log(logBuffer.toString());
+
+        // + 1 to skip the \n
+        if (n + 1 < slicedBuffer.length) {
+          this.buffer = slicedBuffer.slice(n + 1);
+        } else {
+          this.buffer = null;
+        }
+      }
+      cb(undefined, length, buffer);
+    }
+  }
+
+  stdin = new UselessFile();
+  stdout = new ConsoleFile((msg) => console.log(msg));
+  stderr = new ConsoleFile((msg) => console.error(msg));
+}

--- a/kernel/src/stdio_handles.ts
+++ b/kernel/src/stdio_handles.ts
@@ -44,7 +44,7 @@ class UselessFile extends BaseFile implements File {
   }
 }
 
-if (process && !(process as any).browser) {
+if (!(typeof process === "undefined" || (process as any).browser)) {
   interface Request {
     buffer: Buffer;
     offset: number;

--- a/kernel/src/worker.ts
+++ b/kernel/src/worker.ts
@@ -1,0 +1,24 @@
+import * as nodeWorkers from "worker_threads";
+
+export interface OnMessage {
+  onMessage(msg: any): void;
+}
+
+export interface PostMessage {
+  postMessage(msg: any): void;
+}
+
+export let makeWorker: (path: string, receiver: OnMessage) => PostMessage;
+if (typeof Worker !== "undefined") {
+  makeWorker = (path, receiver) => {
+    const worker = new Worker(path);
+    worker.onmessage = msg => receiver.onMessage(msg.data);
+    return { postMessage: msg => worker.postMessage(msg) };
+  };
+} else {
+  makeWorker = (path, receiver) => {
+    const worker = new nodeWorkers.Worker(path);
+    worker.on("message", msg => receiver.onMessage(msg));
+    return { postMessage: msg => worker.postMessage(msg) };
+  }
+}

--- a/kernel/src/worker.ts
+++ b/kernel/src/worker.ts
@@ -1,24 +1,30 @@
-import * as nodeWorkers from "worker_threads";
-
 export interface OnMessage {
   onMessage(msg: any): void;
 }
 
 export interface PostMessage {
-  postMessage(msg: any): void;
+  postMessage(msg: any, transferList?: [any]): void;
+  close(): void;
 }
 
-export let makeWorker: (path: string, receiver: OnMessage) => PostMessage;
+export let makeWorker: (path: string, receiver: OnMessage) => Promise<PostMessage>;
 if (typeof Worker !== "undefined") {
-  makeWorker = (path, receiver) => {
+  makeWorker = async (path, receiver) => {
     const worker = new Worker(path);
     worker.onmessage = msg => receiver.onMessage(msg.data);
-    return { postMessage: msg => worker.postMessage(msg) };
+    return {
+      postMessage: (msg, transferList) => worker.postMessage(msg, transferList),
+      close: () => {}
+    };
   };
 } else {
-  makeWorker = (path, receiver) => {
+  makeWorker = async (path, receiver) => {
+    const nodeWorkers = await import("worker_threads");
     const worker = new nodeWorkers.Worker(path);
     worker.on("message", msg => receiver.onMessage(msg));
-    return { postMessage: msg => worker.postMessage(msg) };
+    return {
+      postMessage: (msg, transferList) => worker.postMessage(msg, transferList),
+      close: () => worker.unref()
+    };
   }
 }

--- a/kernel/tsconfig.json
+++ b/kernel/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "outDir": "dist",
+    "lib": ["dom", "es2015", "es2016", "es2017"],
+    "module": "commonjs",
+    "declaration": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
The plan here is to move all the syscall implementations into the kernel space. For each syscall the process makes to the kernel, it will `postMessage` a `SharedArrayBuffer` containing all the relevant information to the kernel, then `Atomics.wait` on the buffer. The kernel will then do all the appropriate work and `Atomics.wake` the process with results.

To do all of this on nodejs, we can use [the `worker_threads`](https://nodejs.org/api/worker_threads.html) module. It's experimental, but so is everything about WebGHC, so this doesn't bother me :P

This is WIP until the new kernel can actually run wasm programs.