### PR TITLE
Add arg and env logic.

### DIFF
--- a/src/node_runner.ts
+++ b/src/node_runner.ts
@@ -7,12 +7,13 @@ async function main(): Promise<void> {
     var args = process.argv.splice(process.execArgv.length + 2);
 
     if (args.length == 0) {
-      console.log('Usage: node node_runner.js <wasm-executable-name>');
+      console.log('Usage: node node_runner.js <wasm-executable-name> [<args>]');
       process.exit(1);
     } else {
       const execName: string = args[0];
       const fs = await configureFileSystem({ devices: {} });
-      process.exit((await Process.instantiateProcess(fs, execName)).start());
+      const env = Object.entries(process.env).map(([k, v]) => (k + "=" + v));
+      process.exit((await Process.instantiateProcess(fs, execName)).start(args, env));
     }
   } catch(e) {
     console.error(e);

--- a/src/worker_runner.ts
+++ b/src/worker_runner.ts
@@ -3,5 +3,5 @@ import { connectParent } from "./worker";
 
 connectParent({ onMessage: async msg => {
   const fs = await configureFileSystem({ devices: {} });
-  (await Process.instantiateProcess(fs, msg)).start();
+  (await Process.instantiateProcess(fs, msg)).start([], []);
 }});


### PR DESCRIPTION
This requires a change to the signature of the _start function in
musl.  Usually _start is given the location of argc, argv, ... in
esp.  However here we don't have any registers we could setup
properly.  Thus we'll pass into _start the offset instead.

The required musl change is:
```
diff --git a/arch/wasm32/crt_arch.h b/arch/wasm32/crt_arch.h
index 71c98504..d536caae 100644
--- a/arch/wasm32/crt_arch.h
+++ b/arch/wasm32/crt_arch.h
@@ -1,8 +1,7 @@
 #ifndef SHARED
 void _start_c(long *p);

-void _start(void) {
-  long p = 0;
-  _start_c(&p);
+void _start(long *p) {
+  _start_c(p);
 }
 #endif
 ```